### PR TITLE
Fixed broken link

### DIFF
--- a/_posts/2018-01-20-staticman-vs-disqus.md
+++ b/_posts/2018-01-20-staticman-vs-disqus.md
@@ -14,7 +14,7 @@ The awesome theme that I'm using is [minimal mistakes](https://mmistakes.github.
 # Major Lessons 
 I prefer Staticman over all other commenting tools because it keeps the user data where it belongs: on your GitHub repository. Disqus and similar services keep the comments on their servers and (I think for the exact reason) are filtered in some countries like Iran. 
 
-The problem is that I'm using [non-supported Jekyll plugins]){{ site.baseurl }}{% post_url 2018-01-18-jekyll-scholar %}), I have delegated the deploy process to the [Netlify](https://www.netlify.com/) for the website links to work properly I needed to set the `url` in the `config.yml` to `https://aasiaeet.netlify.com`. 
+The problem is that I'm using [non-supported Jekyll plugins]{{ site.baseurl }}{% post_url 2018-01-18-jekyll-scholar %}), I have delegated the deploy process to the [Netlify](https://www.netlify.com/) for the website links to work properly I needed to set the `url` in the `config.yml` to `https://aasiaeet.netlify.com`. 
 
 I think this url setup is the main reason that Staticman is not working for me. By default it tries to commit to the `{url}\{GitHub username}\repository name` and having the Netlify as the url confuses it. 
 


### PR DESCRIPTION
I'm sorry that you didn't manage to integrate Staticman into your blog.  Half a year after you wrote this article, Staticman's native support for GitLab was available.  As a result, its API scheme has been promoted to version 3.  This is adopted by a popular Jekyll theme named [Beautiful Jekyll](https://github.com/daattali/beautiful-jekyll/) in PR 440.  Perhaps that might help you set up Staticman.